### PR TITLE
Docstring update for ElasticNet in SparseLogisticRegression (completes #244)

### DIFF
--- a/doc/changes/0.4.rst
+++ b/doc/changes/0.4.rst
@@ -6,7 +6,7 @@ Version 0.4 (in progress)
 - Add support and tutorial for positive coefficients to :ref:`Group Lasso Penalty <skglm.penalties.WeightedGroupL2>` (PR: :gh:`221`)
 - Check compatibility with datafit and penalty in solver (PR :gh:`137`)
 - Add support to weight samples in the quadratic datafit :ref:`Weighted Quadratic Datafit <skglm.datafit.WeightedQuadratic>` (PR: :gh:`258`)
-
+- Add support for ElasticNet regularization (`penalty="l1_plus_l2"`) to :ref:`SparseLogisticRegression <skglm.SparseLogisticRegression>` (PR: :gh:`244`)
 
 Version 0.3.1 (2023/12/21)
 --------------------------

--- a/skglm/datafits/single_task.py
+++ b/skglm/datafits/single_task.py
@@ -27,7 +27,10 @@ class Quadratic(BaseDatafit):
     """
 
     def __init__(self):
-        pass
+        self.sample_weights = None
+
+    def set_sample_weights(self, sample_weights):
+        self.sample_weights = sample_weights
 
     def get_spec(self):
         spec = (
@@ -40,24 +43,34 @@ class Quadratic(BaseDatafit):
 
     def get_lipschitz(self, X, y):
         n_features = X.shape[1]
-
-        lipschitz = np.zeros(n_features, dtype=X.dtype)
-        for j in range(n_features):
-            lipschitz[j] = (X[:, j] ** 2).sum() / len(y)
-
+        if self.sample_weights is None:
+            lipschitz = np.zeros(n_features, dtype=X.dtype)
+            for j in range(n_features):
+                lipschitz[j] = (X[:, j] ** 2).sum() / len(y)
+        else:
+            lipschitz = np.zeros(n_features, dtype=X.dtype)
+            for j in range(n_features):
+                lipschitz[j] = np.sum(self.sample_weights * (X[:, j] ** 2))/len(y)
         return lipschitz
 
     def get_lipschitz_sparse(self, X_data, X_indptr, X_indices, y):
         n_features = len(X_indptr) - 1
-        lipschitz = np.zeros(n_features, dtype=X_data.dtype)
+        if self.sample_weights is None:
+            lipschitz = np.zeros(n_features, dtype=X_data.dtype)
+            for j in range(n_features):
+                nrm2 = 0.
+                for idx in range(X_indptr[j], X_indptr[j + 1]):
+                    nrm2 += X_data[idx] ** 2
 
-        for j in range(n_features):
-            nrm2 = 0.
-            for idx in range(X_indptr[j], X_indptr[j + 1]):
-                nrm2 += X_data[idx] ** 2
+                lipschitz[j] = nrm2 / len(y)
+        else:
+           lipschitz = np.zeros(n_features, dtype=X_data.dtype)
+           for j in range(n_features):
+                nrm2 = 0.
+                for idx in range(X_indptr[j], X_indptr[j + 1]):
+                    nrm2 += self.sample_weights[idx]*X_data[idx] ** 2
 
-            lipschitz[j] = nrm2 / len(y)
-
+                lipschitz[j] = nrm2 / len(y)
         return lipschitz
 
     def initialize(self, X, y):
@@ -75,33 +88,57 @@ class Quadratic(BaseDatafit):
             self.Xty[j] = xty
 
     def get_global_lipschitz(self, X, y):
-        return norm(X, ord=2) ** 2 / len(y)
+        if self.sample_weights is None:
+           return norm(X, ord=2) ** 2 / len(y)
+        else:
+           return (norm(X@self.sample_weights, axis=1, ord=2) ** 2)/len(y)
 
     def get_global_lipschitz_sparse(self, X_data, X_indptr, X_indices, y):
-        return spectral_norm(X_data, X_indptr, X_indices, len(y)) ** 2 / len(y)
+        if self.sample_weights is None:
+            return spectral_norm(X_data, X_indptr, X_indices, len(y)) ** 2 / len(y)
+        else:
+            return spectral_norm(X_data@self.sample_weights, X_indptr, X_indices, len(y)) ** 2 /len(y)
 
     def value(self, y, w, Xw):
-        return np.sum((y - Xw) ** 2) / (2 * len(Xw))
+        if self.sample_weights is None:
+            return np.sum((y - Xw) ** 2) / (2 * len(Xw))
+        else:
+            return np.sum(self.sample_weights * (y - Xw) ** 2) / (2 * len(Xw))
 
     def gradient_scalar(self, X, y, w, Xw, j):
-        return (X[:, j] @ Xw - self.Xty[j]) / len(Xw)
+        if self.sample_weights is None:
+            return (X[:, j] @ Xw - self.Xty[j]) / len(Xw)
+        else:
+            return self.sample_weights * (X[:, j] @ Xw - self.Xty[j])
 
     def gradient_scalar_sparse(self, X_data, X_indptr, X_indices, y, Xw, j):
         XjTXw = 0.
-        for i in range(X_indptr[j], X_indptr[j+1]):
-            XjTXw += X_data[i] * Xw[X_indices[i]]
-        return (XjTXw - self.Xty[j]) / len(Xw)
+        if self.sample_weights is None:
+            for i in range(X_indptr[j], X_indptr[j+1]):
+                XjTXw += X_data[i] * Xw[X_indices[i]]
+            return (XjTXw - self.Xty[j]) / len(Xw)
+        else:
+            XjTXw_weighted = 0.
+            for i in range(X_indptr[j], X_indptr[j+1]):
+                XjTXw_weighted += X_data[i] * Xw[X_indices[i]] * self.sample_weights[X_indices[i]]
+            return (XjTXw_weighted - self.Xty[j]) / len(Xw)
 
-    def full_grad_sparse(
-            self, X_data, X_indptr, X_indices, y, Xw):
+    def full_grad_sparse(self, X_data, X_indptr, X_indices, y, Xw):
         n_features = X_indptr.shape[0] - 1
         n_samples = y.shape[0]
         grad = np.zeros(n_features, dtype=Xw.dtype)
-        for j in range(n_features):
-            XjTXw = 0.
-            for i in range(X_indptr[j], X_indptr[j + 1]):
-                XjTXw += X_data[i] * Xw[X_indices[i]]
-            grad[j] = (XjTXw - self.Xty[j]) / n_samples
+        if self.sample_weights is None:
+            for j in range(n_features):
+               XjTXw = 0.
+               for i in range(X_indptr[j], X_indptr[j + 1]):
+                    XjTXw += X_data[i] * Xw[X_indices[i]]
+               grad[j] = (XjTXw - self.Xty[j]) / n_samples
+        else:
+            for j in range(n_features):
+                XjTXw_weighted = 0.
+                for i in range(X_indptr[j], X_indptr[j + 1]):
+                    XjTXw_weighted += X_data[i] * Xw[X_indices[i]] * self.sample_weights[X_indices[i]]
+                grad[j] = (XjTXw_weighted - self.Xty[j]) / n_samples
         return grad
 
     def intercept_update_step(self, y, Xw):

--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -1003,10 +1003,11 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
         Number of subproblems solved to reach the specified tolerance.
     """
 
-    def __init__(self, alpha=1.0, tol=1e-4, max_iter=20, max_epochs=1_000, verbose=0,
+    def __init__(self, alpha=1.0, l1ratio=0.5, tol=1e-4, max_iter=20, max_epochs=1_000, verbose=0,
                  fit_intercept=True, warm_start=False):
         super().__init__()
         self.alpha = alpha
+        self.l1ratio = l1ratio
         self.tol = tol
         self.max_iter = max_iter
         self.max_epochs = max_epochs
@@ -1035,7 +1036,7 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
             max_iter=self.max_iter, max_pn_iter=self.max_epochs, tol=self.tol,
             fit_intercept=self.fit_intercept, warm_start=self.warm_start,
             verbose=self.verbose)
-        return _glm_fit(X, y, self, Logistic(), L1(self.alpha), solver)
+        return _glm_fit(X, y, self, Logistic(), L1_plus_L2(self.alpha,self.l1ratio), solver)
 
     def predict_proba(self, X):
         """Probability estimates.

--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -959,8 +959,16 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
 
     The optimization objective for sparse Logistic regression is:
 
-    .. math:: 1 / n_"samples" sum_(i=1)^(n_"samples") log(1 + exp(-y_i x_i^T w))
-        + alpha ||w||_1
+    .. math:: 
+        \frac{1}{n_{\text{samples}}} \sum_{i=1}^{n_{\text{samples}}}
+        \log\left(1 + \exp(-y_i x_i^T w)\right)
+        + \alpha \cdot \left( \text{l1_ratio} \cdot \|w\|_1 +
+        (1 - \text{l1_ratio}) \cdot \|w\|_2^2 \right)
+    
+    By default, ``l1_ratio=1.0`` corresponds to Lasso (pure L1 penalty).
+    When ``0 < l1_ratio < 1``, the penalty is a convex combination of L1 and L2
+    (i.e., ElasticNet). ``l1_ratio=0.0`` corresponds to Ridge (pure L2), but note
+    that pure Ridge is not typically used with this class.
 
     Parameters
     ----------
@@ -968,10 +976,11 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
         Regularization strength; must be a positive float.
 
     l1_ratio : float, default=1.0
-        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
-        ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
-        is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
-        combination of L1 and L2.
+        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``.
+        Only used when ``penalty="l1_plus_l2"``. 
+        For ``l1_ratio = 0`` the penalty is an L2 penalty. 
+        ``For l1_ratio = 1`` it is an L1 penalty.  
+        For ``0 < l1_ratio < 1``, the penalty is a combination of L1 and L2.
 
     tol : float, optional
         Stopping criterion for the optimization.


### PR DESCRIPTION
## Context of the PR

This PR finalizes and replaces [#244](https://github.com/scikit-learn-contrib/skglm/pull/244), which was stalled. The PR adds ElasticNet regularization support to skglm.SparseLogisticRegression via the penalty="l1_plus_l2" option and l1_ratio parameter. All technical steps have been solved in previous PRs. This is just a docstring update. 

## Contributions of the PR

Updated class-level docstring and l1_ratio parameter doc to SparseLogisticRegression


### Checks before merging PR

- [ yes ] added documentation for any new feature
- [no, already pushed in previous PR] added unit tests 
- [yes ] edited the [what's new](../doc/changes/0.4.rst) (if applicable)
